### PR TITLE
Fixed ui issue when a player leaves the server

### DIFF
--- a/gamemode/ui/util.cl.lua
+++ b/gamemode/ui/util.cl.lua
@@ -35,13 +35,11 @@ function GenerateSurfaceCircle(x, y, radius, arc, ang, quality)
 end
 
 function ProperPlayerName(ply)
-	local name
-
-	-- if IsLocalPlayer(ply) then
-	-- 	name = "you"
-	-- else
-		name = ply:GetName()
-	-- end
+	local name = "Disconnected"
+	
+	if (ply:IsValid()) then
+	    name = ply:GetName()
+    end
 
 	return name
 end

--- a/gamemode/ui/util.cl.lua
+++ b/gamemode/ui/util.cl.lua
@@ -35,11 +35,13 @@ function GenerateSurfaceCircle(x, y, radius, arc, ang, quality)
 end
 
 function ProperPlayerName(ply)
-	local name = "Disconnected"
-	
-	if (ply:IsValid()) then
+	local name
+
+	if IsValid(ply) then
 	    name = ply:GetName()
-    end
+	else
+		name = "Disconnected"
+	end
 
 	return name
 end


### PR DESCRIPTION
Fixed the issue "[ERROR] gamemodes/emm/gamemode/ui/util.cl.lua:43: Tried to use a NULL entity!"
This issue occured when the player leaves the server however the server is still trying to access the player's name